### PR TITLE
ypbind3_binding_dup.c: Include string.h for strdup declaration

### DIFF
--- a/lib/ypbind3_binding_dup.c
+++ b/lib/ypbind3_binding_dup.c
@@ -19,6 +19,7 @@
 
 #if defined(HAVE_YPBIND3)
 
+#include <string.h>
 #include <rpcsvc/yp_prot.h>
 #include "internal.h"
 

--- a/src/yp_dump_binding.c
+++ b/src/yp_dump_binding.c
@@ -26,6 +26,7 @@
 #include <libintl.h>
 #include <locale.h>
 #include <getopt.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <arpa/inet.h>
 #include <rpcsvc/ypclnt.h>


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>