### PR TITLE
yppasswd.c check if clnt is NULL after clnt_create()

### DIFF
--- a/src/yppasswd.c
+++ b/src/yppasswd.c
@@ -281,6 +281,11 @@ ypgetpw (char *master, char *domainname, char *name, int uid)
   CLIENT *clnt;
 
   clnt = clnt_create (master, YPPROG, YPVERS, "udp");
+
+  /* clnt_create can return NULL in some cases */
+  if (clnt == NULL)
+	return NULL;
+
   clnt->cl_auth = authunix_create_default ();
 
   if (name == NULL)


### PR DESCRIPTION
In yppaswd.c can occur situation when function clnt_create() return NULL, which lead to SIGSEGV. This situation probably occurred here: https://bugzilla.redhat.com/show_bug.cgi?id=1671452. Solution could by check whether variable clnt is NULL after clnt_create.